### PR TITLE
Task 2: Backend Integration

### DIFF
--- a/bot/handlers/commands/health.py
+++ b/bot/handlers/commands/health.py
@@ -1,12 +1,20 @@
 """Handler for /health command."""
 
+from services.lms_api import get_api_client
+
 
 async def handle_health() -> str:
     """
     Handle the /health command.
-    
+
     Returns:
-        Backend health status.
+        Backend health status with item count or error message.
     """
-    # TODO: Task 2 - call backend API
-    return "Backend status: OK (placeholder)"
+    client = get_api_client()
+    items = await client.get_items()
+
+    if items is None:
+        return "Backend error: connection refused. Check that the services are running."
+
+    item_count = len(items)
+    return f"Backend is healthy. {item_count} items available."

--- a/bot/handlers/commands/labs.py
+++ b/bot/handlers/commands/labs.py
@@ -1,12 +1,35 @@
 """Handler for /labs command."""
 
+from services.lms_api import get_api_client
+
 
 async def handle_labs() -> str:
     """
     Handle the /labs command.
-    
+
     Returns:
-        List of available labs.
+        Formatted list of available labs.
     """
-    # TODO: Task 2 - call backend API
-    return "Available labs: lab-01, lab-02, lab-03 (placeholder)"
+    client = get_api_client()
+    items = await client.get_items()
+
+    if items is None:
+        return "Backend error: connection refused. Check that the services are running."
+
+    # Extract labs from items (items have 'id', 'title', 'type' fields)
+    labs = []
+    for item in items:
+        if item.get("type") == "lab":
+            lab_id = item.get("id")
+            lab_title = item.get("title")
+            if lab_id and lab_title:
+                labs.append((lab_id, lab_title))
+
+    if not labs:
+        return "No labs available."
+
+    lines = ["Available labs:"]
+    for lab_id, lab_title in sorted(labs, key=lambda x: x[0]):
+        lines.append(f"- {lab_title}")
+
+    return "\n".join(lines)

--- a/bot/handlers/commands/scores.py
+++ b/bot/handlers/commands/scores.py
@@ -1,15 +1,38 @@
 """Handler for /scores command."""
 
+from services.lms_api import get_api_client
+
 
 async def handle_scores(lab: str) -> str:
     """
     Handle the /scores command.
-    
+
     Args:
         lab: The lab identifier (e.g., 'lab-04').
-    
+
     Returns:
-        Scores for the specified lab.
+        Per-task pass rates for the specified lab.
     """
-    # TODO: Task 2 - call backend API
-    return f"Scores for {lab}: Task 1: 80%, Task 2: 75% (placeholder)"
+    if not lab or lab == "unknown":
+        return "Usage: /scores <lab> (e.g., /scores lab-04)"
+
+    client = get_api_client()
+    pass_rates = await client.get_pass_rates(lab)
+
+    if pass_rates is None:
+        return (
+            f"Backend error: connection refused. Check that the services are running."
+        )
+
+    if not pass_rates:
+        return f"No scores found for lab '{lab}'. The lab may not exist."
+
+    # Format pass rates (API returns 'task', 'avg_score', 'attempts')
+    lines = [f"Pass rates for {lab}:"]
+    for rate in pass_rates:
+        task_name = rate.get("task", "Unknown task")
+        avg_score = rate.get("avg_score", 0)
+        attempts = rate.get("attempts", 0)
+        lines.append(f"- {task_name}: {avg_score:.1f}% ({attempts} attempts)")
+
+    return "\n".join(lines)

--- a/bot/services/__init__.py
+++ b/bot/services/__init__.py
@@ -1,0 +1,1 @@
+"""Services for external APIs (LMS backend, LLM, etc.)."""

--- a/bot/services/lms_api.py
+++ b/bot/services/lms_api.py
@@ -1,0 +1,79 @@
+"""LMS API client service."""
+
+import httpx
+from config import get_settings
+
+
+class LMSAPIClient:
+    """Client for the LMS backend API."""
+
+    def __init__(self) -> None:
+        self._settings = get_settings()
+        self._base_url = self._settings.lms_api_base_url
+        self._api_key = self._settings.lms_api_key
+        self._headers = {"Authorization": f"Bearer {self._api_key}"}
+
+    async def get_items(self) -> list[dict] | None:
+        """
+        Fetch all items (labs and tasks) from the backend.
+
+        Returns:
+            List of items, or None if the backend is unavailable.
+        """
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self._base_url}/items/",
+                    headers=self._headers,
+                    timeout=5.0,
+                )
+                response.raise_for_status()
+                return response.json()
+        except httpx.ConnectError as e:
+            # Backend not running
+            return None
+        except httpx.HTTPStatusError as e:
+            # HTTP error (4xx, 5xx)
+            return None
+        except Exception:
+            # Any other error
+            return None
+
+    async def get_pass_rates(self, lab: str) -> list[dict] | None:
+        """
+        Fetch pass rates for a specific lab.
+
+        Args:
+            lab: Lab identifier (e.g., "lab-04").
+
+        Returns:
+            List of pass rate data, or None if unavailable.
+        """
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self._base_url}/analytics/pass-rates",
+                    params={"lab": lab},
+                    headers=self._headers,
+                    timeout=5.0,
+                )
+                response.raise_for_status()
+                return response.json()
+        except httpx.ConnectError:
+            return None
+        except httpx.HTTPStatusError:
+            return None
+        except Exception:
+            return None
+
+
+# Global client instance
+_api_client: LMSAPIClient | None = None
+
+
+def get_api_client() -> LMSAPIClient:
+    """Get the LMS API client instance."""
+    global _api_client
+    if _api_client is None:
+        _api_client = LMSAPIClient()
+    return _api_client


### PR DESCRIPTION
Closes #2

## Summary
Implemented backend integration for all slash commands:

- `/health` - Calls GET /items/ and reports item count
- `/labs` - Lists all labs from backend
- `/scores <lab>` - Fetches per-task pass rates

## Changes
- Added `LMSAPIClient` service with Bearer token auth
- Updated handlers to use real API calls
- Added error handling for connection failures
- Handles edge cases (missing args, unknown labs)

## Testing
All commands verified with `--test` mode:
- `/health` shows "Backend is healthy. 50 items available."
- `/labs` lists 7 labs
- `/scores lab-04` shows task scores with percentages
- Error handling shows "connection refused" when backend is down