### PR TITLE
Task 3: Intent-Based Natural Language Routing

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -3,8 +3,9 @@
 Telegram bot entry point with --test mode.
 
 Usage:
-    uv run bot.py --test "/start"    # Test mode: prints response to stdout
-    uv run bot.py                    # Production: connects to Telegram
+    uv run bot.py --test "/start"           # Test mode: slash commands
+    uv run bot.py --test "hello"            # Test mode: natural language
+    uv run bot.py                           # Production: connects to Telegram
 """
 
 import argparse
@@ -20,6 +21,7 @@ from handlers.commands.help import handle_help
 from handlers.commands.health import handle_health
 from handlers.commands.labs import handle_labs
 from handlers.commands.scores import handle_scores
+from handlers.intent_router import route_intent
 
 
 def parse_args() -> argparse.Namespace:
@@ -28,33 +30,37 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--test",
         type=str,
-        metavar="COMMAND",
-        help="Test mode: run a command and print response to stdout",
+        metavar="MESSAGE",
+        help="Test mode: run a command/message and print response to stdout",
     )
     return parser.parse_args()
 
 
-async def run_test_mode(command: str) -> None:
-    """Run a command in test mode and print the response."""
-    # Strip leading slash if present
-    cmd = command.lstrip("/")
+async def run_test_mode(message: str) -> None:
+    """Run a command or message in test mode and print the response."""
+    # Strip leading slash if present (slash commands)
+    if message.startswith("/"):
+        cmd = message.lstrip("/")
 
-    # Route to appropriate handler
-    if cmd == "start":
-        response = await handle_start()
-    elif cmd == "help":
-        response = await handle_help()
-    elif cmd == "health":
-        response = await handle_health()
-    elif cmd == "labs":
-        response = await handle_labs()
-    elif cmd.startswith("scores"):
-        # Extract lab argument if present
-        parts = cmd.split(maxsplit=1)
-        lab = parts[1] if len(parts) > 1 else "unknown"
-        response = await handle_scores(lab)
+        # Route to appropriate handler
+        if cmd == "start":
+            response = await handle_start()
+        elif cmd == "help":
+            response = await handle_help()
+        elif cmd == "health":
+            response = await handle_health()
+        elif cmd == "labs":
+            response = await handle_labs()
+        elif cmd.startswith("scores"):
+            # Extract lab argument if present
+            parts = cmd.split(maxsplit=1)
+            lab = parts[1] if len(parts) > 1 else ""
+            response = await handle_scores(lab)
+        else:
+            response = f"Command /{cmd} not implemented yet. Try natural language!"
     else:
-        response = f"Command /{cmd} not implemented yet"
+        # Natural language message - use intent router
+        response = await route_intent(message)
 
     print(response)
 

--- a/bot/handlers/intent_router.py
+++ b/bot/handlers/intent_router.py
@@ -1,0 +1,218 @@
+"""Intent router: uses LLM to interpret natural language and call tools."""
+
+import json
+import sys
+import httpx
+from services.llm_client import get_llm_client
+from services.lms_api import get_api_client
+from config import get_settings
+
+
+# System prompt for the LLM
+SYSTEM_PROMPT = """You are a helpful assistant for an LMS (Learning Management System). 
+You have access to tools that fetch data about labs, learners, scores, and analytics.
+
+When a user asks a question:
+1. First, think about what data you need. If the question involves comparing labs or finding the best/worst, you MUST first call get_items to discover all available labs.
+2. Then call the appropriate tool(s) to get the data for each relevant lab.
+3. Once you have all the data, compare and summarize clearly for the user.
+
+For questions like "which lab has the lowest pass rate" or "compare labs":
+- Step 1: Call get_items to get all lab IDs
+- Step 2: Call get_pass_rates for each lab
+- Step 3: Compare the results and identify the lowest/highest
+
+If the user's message is unclear or ambiguous, ask for clarification.
+If the user greets you, respond warmly and mention what you can help with (labs, scores, pass rates, etc.).
+
+Always use tools to get real data before answering questions about specific labs or scores.
+After calling tools, you will see the results. Use those results to answer the user's question."""
+
+
+async def route_intent(user_message: str) -> str:
+    """
+    Route a natural language message through the LLM.
+
+    Args:
+        user_message: The user's message text.
+
+    Returns:
+        The bot's response text.
+    """
+    llm = get_llm_client()
+    api = get_api_client()
+    tools = llm._get_tools()
+
+    # Initialize conversation with system prompt
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": user_message},
+    ]
+
+    # Tool calling loop
+    max_iterations = 10
+    iteration = 0
+
+    while iteration < max_iterations:
+        iteration += 1
+
+        # Call LLM
+        response = await llm.chat(messages, tools)
+
+        # Check if LLM wants to call tools
+        tool_calls = response.get("tool_calls", [])
+
+        if not tool_calls:
+            # LLM is done - return its response
+            return response.get("content", "I'm not sure how to help with that.")
+
+        # Execute tool calls and collect results
+        tool_results = []
+        for tool_call in tool_calls:
+            function = tool_call.get("function", {})
+            func_name = function.get("name")
+            func_args = function.get("arguments", {})
+
+            # Skip empty tool calls
+            if not func_name:
+                continue
+
+            # Parse arguments if they're a JSON string
+            if isinstance(func_args, str):
+                try:
+                    func_args = json.loads(func_args)
+                except json.JSONDecodeError:
+                    func_args = {}
+
+            # Execute the tool
+            result = await _execute_tool(func_name, func_args, api)
+            tool_results.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call.get("id"),
+                    "content": result,
+                }
+            )
+
+            # Debug output to stderr
+            print(f"[tool] LLM called: {func_name}({func_args})", file=sys.stderr)
+            print(
+                f"[tool] Result: {result[:100]}..."
+                if len(result) > 100
+                else f"[tool] Result: {result}",
+                file=sys.stderr,
+            )
+
+        # Add assistant response and tool results to conversation
+        messages.append(
+            {
+                "role": "assistant",
+                "content": response.get("content"),
+                "tool_calls": tool_calls,
+            }
+        )
+        messages.extend(tool_results)
+
+        print(
+            f"[summary] Feeding {len(tool_results)} tool result(s) back to LLM",
+            file=sys.stderr,
+        )
+
+    # If we get here, we hit max iterations
+    return "I'm having trouble answering that question. Please try rephrasing."
+
+
+async def _execute_tool(func_name: str, func_args: dict, api) -> str:
+    """Execute a tool and return the result as a string."""
+    import json
+
+    try:
+        if func_name == "get_items":
+            result = await api.get_items()
+            return json.dumps(result, default=str)
+        elif func_name == "get_pass_rates":
+            lab = func_args.get("lab", "")
+            result = await api.get_pass_rates(lab)
+            return json.dumps(result, default=str)
+        elif func_name == "get_scores":
+            lab = func_args.get("lab", "")
+            # Call the analytics endpoint directly
+            from config import get_settings
+
+            settings = get_settings()
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{settings.lms_api_base_url}/analytics/scores",
+                    params={"lab": lab},
+                    headers={"Authorization": f"Bearer {settings.lms_api_key}"},
+                )
+                return json.dumps(response.json(), default=str)
+        elif func_name == "get_learners":
+            from config import get_settings
+
+            settings = get_settings()
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{settings.lms_api_base_url}/learners/",
+                    headers={"Authorization": f"Bearer {settings.lms_api_key}"},
+                )
+                return json.dumps(response.json(), default=str)
+        elif func_name == "get_timeline":
+            from config import get_settings
+
+            settings = get_settings()
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{settings.lms_api_base_url}/analytics/timeline",
+                    params={"lab": func_args.get("lab", "")},
+                    headers={"Authorization": f"Bearer {settings.lms_api_key}"},
+                )
+                return json.dumps(response.json(), default=str)
+        elif func_name == "get_groups":
+            from config import get_settings
+
+            settings = get_settings()
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{settings.lms_api_base_url}/analytics/groups",
+                    params={"lab": func_args.get("lab", "")},
+                    headers={"Authorization": f"Bearer {settings.lms_api_key}"},
+                )
+                return json.dumps(response.json(), default=str)
+        elif func_name == "get_top_learners":
+            from config import get_settings
+
+            settings = get_settings()
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{settings.lms_api_base_url}/analytics/top-learners",
+                    params={
+                        "lab": func_args.get("lab", ""),
+                        "limit": func_args.get("limit", 5),
+                    },
+                    headers={"Authorization": f"Bearer {settings.lms_api_key}"},
+                )
+                return json.dumps(response.json(), default=str)
+        elif func_name == "get_completion_rate":
+            from config import get_settings
+
+            settings = get_settings()
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{settings.lms_api_base_url}/analytics/completion-rate",
+                    params={"lab": func_args.get("lab", "")},
+                    headers={"Authorization": f"Bearer {settings.lms_api_key}"},
+                )
+                return json.dumps(response.json(), default=str)
+        elif func_name == "trigger_sync":
+            settings = get_settings()
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    f"{settings.lms_api_base_url}/pipeline/sync",
+                    headers={"Authorization": f"Bearer {settings.lms_api_key}"},
+                )
+                return json.dumps(response.json(), default=str)
+        else:
+            return f"Unknown tool: {func_name}"
+    except Exception as e:
+        return f"Error executing {func_name}: {str(e)}"

--- a/bot/services/llm_client.py
+++ b/bot/services/llm_client.py
@@ -1,0 +1,209 @@
+"""LLM client with tool calling support."""
+
+import json
+import httpx
+from config import get_settings
+
+
+class LLMClient:
+    """Client for LLM API with tool calling support."""
+
+    def __init__(self) -> None:
+        self._settings = get_settings()
+        self._base_url = self._settings.llm_api_base_url
+        self._api_key = self._settings.llm_api_key
+        self._model = self._settings.llm_api_model
+        self._headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _get_tools(self) -> list[dict]:
+        """Return tool definitions for the LLM."""
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_items",
+                    "description": "Get list of all labs and tasks. Use this to discover what labs exist.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_learners",
+                    "description": "Get list of enrolled learners and their groups.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_scores",
+                    "description": "Get score distribution (4 buckets) for a specific lab.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "lab": {
+                                "type": "string",
+                                "description": "Lab identifier, e.g., 'lab-01', 'lab-04'",
+                            }
+                        },
+                        "required": ["lab"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_pass_rates",
+                    "description": "Get per-task average scores and attempt counts for a lab.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "lab": {
+                                "type": "string",
+                                "description": "Lab identifier, e.g., 'lab-01', 'lab-04'",
+                            }
+                        },
+                        "required": ["lab"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_timeline",
+                    "description": "Get submission timeline (submissions per day) for a lab.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "lab": {
+                                "type": "string",
+                                "description": "Lab identifier, e.g., 'lab-01', 'lab-04'",
+                            }
+                        },
+                        "required": ["lab"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_groups",
+                    "description": "Get per-group scores and student counts for a lab.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "lab": {
+                                "type": "string",
+                                "description": "Lab identifier, e.g., 'lab-01', 'lab-04'",
+                            }
+                        },
+                        "required": ["lab"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_top_learners",
+                    "description": "Get top N learners by score for a lab.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "lab": {
+                                "type": "string",
+                                "description": "Lab identifier, e.g., 'lab-01', 'lab-04'",
+                            },
+                            "limit": {
+                                "type": "integer",
+                                "description": "Number of top learners to return, e.g., 5",
+                            },
+                        },
+                        "required": ["lab", "limit"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_completion_rate",
+                    "description": "Get completion rate percentage for a lab.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "lab": {
+                                "type": "string",
+                                "description": "Lab identifier, e.g., 'lab-01', 'lab-04'",
+                            }
+                        },
+                        "required": ["lab"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "trigger_sync",
+                    "description": "Trigger ETL sync to refresh data from autochecker.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                    },
+                },
+            },
+        ]
+
+    async def chat(
+        self, messages: list[dict], tools: list[dict] | None = None
+    ) -> dict:
+        """
+        Send a chat request to the LLM.
+
+        Args:
+            messages: List of message dicts with 'role' and 'content'.
+            tools: Optional list of tool definitions.
+
+        Returns:
+            LLM response dict with 'content' and/or 'tool_calls'.
+        """
+        payload = {
+            "model": self._model,
+            "messages": messages,
+        }
+        if tools:
+            payload["tools"] = tools
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self._base_url}/chat/completions",
+                headers=self._headers,
+                json=payload,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data["choices"][0]["message"]
+
+
+# Global client instance
+_llm_client: LLMClient | None = None
+
+
+def get_llm_client() -> LLMClient:
+    """Get the LLM client instance."""
+    global _llm_client
+    if _llm_client is None:
+        _llm_client = LLMClient()
+    return _llm_client


### PR DESCRIPTION
Closes #3

## Summary
Implemented LLM-powered intent router for natural language queries.

## Features
- 9 tool definitions for all backend endpoints
- Multi-step reasoning: LLM calls tools, results fed back, LLM summarizes
- Debug logging for tool calls in --test mode
- Graceful fallback for unclear messages

## Tools Available
- `get_items` - List all labs
- `get_pass_rates` - Per-task scores for a lab
- `get_scores` - Score distribution
- `get_top_learners` - Top N students
- `get_completion_rate` - Completion percentage
- `get_groups` - Per-group performance
- `get_timeline` - Submission timeline
- `get_learners` - Enrolled students
- `trigger_sync` - Refresh data

## Testing
All acceptance criteria verified:
- `--test "what labs are available"` - Lists all 7 labs
- `--test "which lab has the lowest pass rate"` - Multi-step reasoning, identifies Lab 02
- `--test "asdfgh"` - Helpful fallback message
- `--test "hello"` - Friendly greeting with capabilities